### PR TITLE
training_timer: set timer box to be ltr always

### DIFF
--- a/src/training_timer.rs
+++ b/src/training_timer.rs
@@ -188,6 +188,7 @@ impl Component for TrainingTimer {
                         add_css_class: "timer-label",
                         set_orientation: gtk::Orientation::Horizontal,
                         set_halign: gtk::Align::Center,
+                        set_direction: gtk::TextDirection::Ltr,
                         gtk::Label {
                             #[watch]
                             set_width_chars: width_chars(model.remaining_s, 2),


### PR DESCRIPTION
The time is reversed in RTL languages, so set the box's direction to be ltr always, also in RTL languages.