### PR TITLE
Update brand colors

### DIFF
--- a/data/xyz.safeworlds.hiit.metainfo.xml.in.in
+++ b/data/xyz.safeworlds.hiit.metainfo.xml.in.in
@@ -50,8 +50,8 @@
     <control>touch</control>
   </supports>
   <branding>
-    <color type="primary" scheme_preference="light">#faa298</color>
-    <color type="primary" scheme_preference="dark">#7f2c22</color>
+    <color type="primary" scheme_preference="light">#57e389</color>
+    <color type="primary" scheme_preference="dark">#188653</color>
   </branding>
   <releases>
     <release version="1.8.0" date="2025-02-22">


### PR DESCRIPTION
Sorry, I should have caught this during Circle Review, I noticed it now on the [Circle app page](https://apps.gnome.org/Hiit/) for the first time. The current red doesn't really work with the green, I'd go with something simpler that's closer to the actual icon colors:

![Screenshot From 2025-03-06 00-10-35](https://github.com/user-attachments/assets/d09cc3d2-0916-42b6-b702-746dacad9a29)
