### PR TITLE
chore(desktop): Add HealthFitness and Exercise categories

### DIFF
--- a/data/xyz.safeworlds.hiit.desktop.in.in
+++ b/data/xyz.safeworlds.hiit.desktop.in.in
@@ -4,7 +4,7 @@ Comment=Timer clock for high intensity interval training
 Type=Application
 Exec=hiit
 Terminal=false
-Categories=GNOME;GTK;Utility;
+Categories=GNOME;GTK;HealthFitness;Exercise;Utility;
 # Translators: Search terms to find this application. Do NOT translate or localize the semicolons! The list MUST also end with a semicolon!
 Keywords=Gnome;GTK;Utility;Sports;Exercise;HIIT;Training;Exercise;High intensity interval training;
 # Translators: Do NOT translate or transliterate this text (this is an icon file name)!


### PR DESCRIPTION
HealthFitness and Exercise were recently added as FreeDesktop categories.

You can find HealthFitness as a main category: https://specifications.freedesktop.org/menu/latest/category-registry.html
You can find Exercise as an additional category: https://specifications.freedesktop.org/menu/latest/additional-category-registry.html